### PR TITLE
Add noneof() matcher for arrays containing none of the given elements

### DIFF
--- a/lib/Test/Deep.pm
+++ b/lib/Test/Deep.pm
@@ -100,9 +100,9 @@ while (my ($pkg, $name) = splice @constructors, 0, 2)
       all any array array_each arrayelementsonly arraylength arraylengthonly
       bag bool cmp_bag cmp_deeply cmp_methods cmp_set code eq_deeply
       hash hash_each hashkeys hashkeysonly ignore isa listmethods methods
-      noclass num re reftype regexpmatches regexponly regexpref regexprefonly
-      scalarrefonly scalref set shallow str subbagof subhashof subsetof
-      superbagof superhashof supersetof useclass
+      noclass noneof num re reftype regexpmatches regexponly regexpref
+      regexprefonly scalarrefonly scalref set shallow str subbagof subhashof
+      subsetof superbagof superhashof supersetof useclass
     )
   ];
 
@@ -113,9 +113,9 @@ while (my ($pkg, $name) = splice @constructors, 0, 2)
       all any array array_each arrayelementsonly arraylength arraylengthonly
       bag bool cmp_bag cmp_deeply cmp_methods cmp_set code eq_deeply
       hash hash_each hashkeys hashkeysonly ignore listmethods methods
-      noclass num re reftype regexpmatches regexponly regexpref regexprefonly
-      scalarrefonly scalref set shallow str subbagof subhashof subsetof
-      superbagof superhashof supersetof useclass
+      noclass noneof num re reftype regexpmatches regexponly regexpref
+      regexprefonly scalarrefonly scalref set shallow str subbagof subhashof
+      subsetof superbagof superhashof supersetof useclass
     )
   ];
 
@@ -480,6 +480,13 @@ sub subsetof
 	require Test::Deep::Set;
 
 	return Test::Deep::Set->new(1, "sub", @_);
+}
+
+sub noneof
+{
+        require Test::Deep::Set;
+
+        return Test::Deep::Set->new(1, "none", @_);
 }
 
 sub cmp_set
@@ -1145,7 +1152,7 @@ will result in a set containing 1, 2, 3.
 C<NOTE> See the NOTE on the bag() comparison for some dangers in using
 special comparisons inside set()
 
-=head3 superbagof(@elements), subbagof(@elements), supersetof(@elements) and subsetof(@elements)
+=head3 superbagof(@elements), subbagof(@elements), supersetof(@elements), subsetof(@elements) and noneof(@elements)
 
 @elements is an array of elements.
 
@@ -1158,6 +1165,10 @@ checks that @$data contains at most 2 "1"s, 1 "3" and 1 "4" and
   cmp_deeply($data, supersetof(1, 1, 1, 4));
 
 will check that @$data has at least one "1" and at least one "4".
+
+  cmp_deeply($data, noneof(1, 2, 3));
+
+will check that @$data does not contain any instances of "1", "2" or "3".
 
 These are just special cases of the Set and Bag comparisons so they also
 give you an add() method and they also have the same limitations when using

--- a/lib/Test/Deep/Set.pm
+++ b/lib/Test/Deep/Set.pm
@@ -46,6 +46,7 @@ EOM
 	if (not $diag)
 	{
 		my @got = @$d1;
+                my @found;
 		my @missing;
 		foreach my $expect (@$d2)
 		{
@@ -56,6 +57,7 @@ EOM
 				if (Test::Deep::eq_deeply_cache($got[$i], $expect))
 				{
 					$found = 1;
+                                        push(@found, $expect);
 					splice(@got, $i, 1);
 
 					last unless $IgnoreDupes;
@@ -67,16 +69,22 @@ EOM
 
 
 		my @diags;
-		if (@missing and $SubSup ne "sub")
+		if (@missing and $SubSup ne "sub" && $SubSup ne "none")
 		{
 			push(@diags, "Missing: ".nice_list(\@missing));
 		}
 
-		if (@got and $SubSup ne "sup")
+		if (@got and $SubSup ne "sup" && $SubSup ne "none")
 		{
 			my $got = __PACKAGE__->new($IgnoreDupes, "", @got);
 			push(@diags, "Extra: ".nice_list($got->{val}));
 		}
+
+                if (@found and $SubSup eq "none")
+                {
+                        my $found = __PACKAGE__->new($IgnoreDupes, "", @found);
+                        push(@diags, "Extra: ".nice_list($found->{val}));
+                }
 
 		$diag = join("\n", @diags);
 	}
@@ -101,6 +109,7 @@ sub diagnostics
 	my $type = $self->{IgnoreDupes} ? "Set" : "Bag";
 	$type = "Sub$type" if $self->{SubSup} eq "sub";
 	$type = "Super$type" if $self->{SubSup} eq "sup";
+        $type = "NoneOf" if $self->{SubSup} eq "none";
 
 	my $error = $last->{diag};
 	my $diag = <<EOM;

--- a/t/bag.t
+++ b/t/bag.t
@@ -243,6 +243,33 @@ EOM
 		},
 		"subbagof no"
 	);
+{
+        check_test(
+                sub {
+                        cmp_deeply(['a', 'a', 'b', 'c', 'b'], noneof('d', 'e', 'f'));
+                },
+                {
+                        actual_ok => 1,
+                        diag => "",
+                },
+                "noneof yes"
+        );
+
+        check_test(
+                sub {
+                        cmp_deeply(['a', 'a', 'b', 'c', 'b'], noneof('b', 'c', 'd', 'e'));
+                },
+                {
+                    actual_ok => 0,
+                    diag => <<'EOM',
+Comparing $data as a NoneOf
+Extra: 'b', 'c'
+EOM
+                },
+                "noneof no"
+        );
+}
+
 
   eval {
     my @res = run_tests(

--- a/t/set.t
+++ b/t/set.t
@@ -258,6 +258,33 @@ EOM
 }
 
 {
+        check_test(
+                sub {
+                        cmp_deeply(['a', 'b', 'c'], noneof('d', 'e', 'f'));
+                },
+                {
+                        actual_ok => 1,
+                        diag => "",
+                },
+                "noneof yes"
+        );
+
+        check_test(
+                sub {
+                        cmp_deeply(['a', 'b', 'c'], noneof('b', 'c', 'd', 'e'));
+                },
+                {
+                    actual_ok => 0,
+                    diag => <<'EOM',
+Comparing $data as a NoneOf
+Extra: 'b', 'c'
+EOM
+                },
+                "noneof no"
+        );
+}
+
+{
 	check_test(
 		sub {
 			cmp_deeply([1, undef, undef], set(undef, 1, undef));


### PR DESCRIPTION
This also limits the scope of the skip_todo() in set.t to what's actually broken
