### PR TITLE
Topic/metadata fix

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -48,12 +48,17 @@ WriteMakefile(
   ($mm_ver < 6.46 ? () : (META_MERGE => {
     'meta-spec' => { version => 2 },
     dynamic_config => 1,
-    resources => {
-        license     =>      'http://dev.perl.org/licenses/',
-        homepage    =>      'http://github.com/rjbs/Test-Deep/',
-        bugtracker  =>      'http://github.com/rjbs/Test-Deep/issues/',
-        repository  =>      'http://github.com/rjbs/Test-Deep/',
-        MailingList =>      'http://lists.perl.org/list/perl-qa.html',
+    resources       => {
+      homepage      => 'http://github.com/rjbs/Test-Deep/',
+      repository    => {
+         url        => 'https://github.com/rjbs/Test-Deep.git',
+         web        => 'https://github.com/rjbs/Test-Deep',
+         type       => 'git',
+      },
+      bugtracker    => {
+         web        => 'http://github.com/rjbs/Test-Deep/issues',
+      },
+      x_MailingList => 'http://lists.perl.org/list/perl-qa.html',
     },
   })),
 

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -59,6 +59,7 @@ WriteMakefile(
          web        => 'http://github.com/rjbs/Test-Deep/issues',
       },
       x_MailingList => 'http://lists.perl.org/list/perl-qa.html',
+      x_IRC         => 'irc://irc.perl.org/#perl-qa',
     },
   })),
 


### PR DESCRIPTION

15:21 < neilb> anyone fancy a bonus PR? Test-Deep tries to set the github repo in metadata, but it sets meta-spec to 2, then sets resources version 1 stylee: https://github.com/rjbs/Test-Deep/blob/master/Makefile.PL — a quick PR will 
               make it a candidate for this PRC :-)
16:10 <@ether> I'll fix it
16:15 <@ether> after all, it's me that broke it :)
