### PR TITLE
Prevent clobbering $! and $^E when loading modules.

### DIFF
--- a/lib/Test/Deep.pm
+++ b/lib/Test/Deep.pm
@@ -76,6 +76,7 @@ while (my ($pkg, $name) = splice @constructors, 0, 2)
 	my $file = "$full_pkg.pm";
 	$file =~ s#::#/#g;
 	my $sub = sub {
+		local ($!, $^E);
 		require $file;
 		return $full_pkg->new(@_);
 	};

--- a/t/OS_ERROR_and_EXTENDED_OS_ERROR.t
+++ b/t/OS_ERROR_and_EXTENDED_OS_ERROR.t
@@ -1,0 +1,20 @@
+use strict;
+use warnings;
+
+use Test::More;
+use Test::NoWarnings;
+
+plan tests => 2;
+
+use Test::Deep;
+
+{
+    local $! = 5;
+    all();
+
+    is(
+        0 + $!,
+        5,
+        'loading all() leaves $! alone',
+    );
+}


### PR DESCRIPTION
Issue #26: This prevents upsetting (fragile?) tests that expect $!
to remain unchanged when using a Test::Deep method.