### PR TITLE
Remove use of Test::NoWarnings

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,7 @@
 Revision history for Test-Deep
 
+        - remove use of Test::NoWarnings for user-facing tests
+
 0.117     2015-06-21
         - do not lose argument(s) to import
           (fixes https://github.com/rjbs/Test-Deep/issues/29 )

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -32,9 +32,8 @@ WriteMakefile(
   },
 
   ( $ExtUtils::MakeMaker::VERSION < 6.63_03 ? 'BUILD_REQUIRES' : 'TEST_REQUIRES' ) => {
-    'Test::More'       => '0',
+    'Test::More'       => '0.88',
     'Test::Tester'     => $tt_prereq,
-    'Test::NoWarnings' => '0.02',
   },
 
   LICENSE => "perl",

--- a/t/cache.t
+++ b/t/cache.t
@@ -1,9 +1,8 @@
 use strict;
 use warnings;
 
-use Test::More qw(no_plan);
-
-use Test::NoWarnings;
+use Test::More 0.88;
+use if $ENV{AUTHOR_TESTING}, 'Test::Warnings';
 
 use Test::Deep::Cache;
 
@@ -38,3 +37,5 @@ use Test::Deep::Cache;
 	$cache->finish(1);
 	ok($cache->cmp($b, $c), "still there");
 }
+
+done_testing;

--- a/t/deep_utils.t
+++ b/t/deep_utils.t
@@ -1,9 +1,8 @@
 use strict;
 use warnings;
 
-use Test::More qw(no_plan);
-
-use Test::NoWarnings;
+use Test::More 0.88;
+use if $ENV{AUTHOR_TESTING}, 'Test::Warnings';
 
 use Test::Deep qw( cmp_deeply descend render_stack methods deep_diag class_base );
 
@@ -30,3 +29,5 @@ use Test::Deep qw( cmp_deeply descend render_stack methods deep_diag class_base 
 	is($class, "Regexp", "class_base class regexp");
 	is($base, ($] < 5.011 ? "Regexp" : "REGEXP"), "class_base base regexp");
 }
+
+done_testing;

--- a/t/notest_extra.t
+++ b/t/notest_extra.t
@@ -1,10 +1,12 @@
 use strict;
 use warnings;
 
-use Test::More tests => 3;
-use Test::NoWarnings;
+use Test::More 0.88;
+use if $ENV{AUTHOR_TESTING}, 'Test::Warnings';
 
 use Test::Deep::NoTest;
 
 ok(eq_deeply([], []), "got eq_deeply");
 ok(! eq_deeply({}, []), "eq_deeply works");
+
+done_testing;

--- a/t/std.pm
+++ b/t/std.pm
@@ -1,10 +1,14 @@
-use Test::Tester;
+use strict;
+use warnings;
 
-use Test::More qw(no_plan);
+use Test::Tester;
+use Test::More 0.88;
 use if $ENV{AUTHOR_TESTING}, 'Test::Warnings';
 
 use Test::Deep;
 
 Test::Deep::builder(Test::Tester::capture());
+
+END { done_testing; }
 
 1;

--- a/t/std.pm
+++ b/t/std.pm
@@ -1,8 +1,7 @@
 use Test::Tester;
 
 use Test::More qw(no_plan);
-
-use Test::NoWarnings;
+use if $ENV{AUTHOR_TESTING}, 'Test::Warnings';
 
 use Test::Deep;
 


### PR DESCRIPTION
@dagolden's hitlist (https://gist.github.com/dagolden/69a93d45a34110498158) shows Test-Deep as the top consumer of Test-NoWarnings.  Since warning tests for users have been considered to be harmful for a while (it prevents installation if perl core or something upstream introduces a new warning), these have been changed to run only for authors.