### PR TITLE
Prevent action-at-a-distance from clobbered $@.

### DIFF
--- a/lib/Test/Deep/All.pm
+++ b/lib/Test/Deep/All.pm
@@ -10,7 +10,7 @@ sub init
 	my $self = shift;
 
 	my @list = map {
-	  eval { $_->isa('Test::Deep::All') }
+	  UNIVERSAL::isa($_, 'Test::Deep::All')
 	  ? @{ $_->{val} }
 	  : Test::Deep::wrap($_)
 	} @_;

--- a/lib/Test/Deep/Any.pm
+++ b/lib/Test/Deep/Any.pm
@@ -10,7 +10,7 @@ sub init
 	my $self = shift;
 
 	my @list = map {
-	  eval { $_->isa('Test::Deep::Any') }
+	  UNIVERSAL::isa($_, 'Test::Deep::Any')
 	  ? @{ $_->{val} }
 	  : Test::Deep::wrap($_)
 	} @_;

--- a/lib/Test/Deep/Cache/Simple.pm
+++ b/lib/Test/Deep/Cache/Simple.pm
@@ -37,6 +37,8 @@ sub add
 	{
 		local $SIG{__DIE__};
 
+        local $@;
+
 		# cannot weaken read only refs, no harm if we can't as they never
 		# disappear
 		eval{weaken($d1)};

--- a/lib/Test/Deep/Methods.pm
+++ b/lib/Test/Deep/Methods.pm
@@ -40,6 +40,8 @@ sub descend
 		my ($call, $exp_res) = @$method;
 		my ($name, @args) = @$call;
 
+    local $@;
+
     my $got_res;
     if (! eval { $got_res = $self->call_method($got, $call); 1 }) {
       die $@ unless $@ =~ /\ACan't locate object method "\Q$name"/;


### PR DESCRIPTION
Issue #36: The clobber of $@ was breaking tests in at least one other
CPAN module, IO::Die.