### PR TITLE
Support of NOT

### DIFF
--- a/lib/Test/Deep.pm
+++ b/lib/Test/Deep.pm
@@ -1218,6 +1218,24 @@ a test passes then none of the tests after that will be attempted.
 
 You can also use overloading with C<|> similarly to all().
 
+=head3 none
+
+  cmp_deeply( $got, none(@non_expecteds) );
+
+C<@non_expecteds> is an array of non-expected structures.
+
+This can be used to compare data against multiple non-expected results and
+make sure that no one of them matches.
+
+You can also use overloading with C<~> similarly to C<none($non_expected)>.
+So you can write
+
+  any( re("^wi"), none( isa("Person"), methods(name => 'John') ) )
+
+as
+
+   re("^wi") | ^( isa("Person") | methods(name => 'John') )
+
 =head3 Isa
 
   cmp_deeply( $got, Isa($class) );

--- a/lib/Test/Deep/Cmp.pm
+++ b/lib/Test/Deep/Cmp.pm
@@ -6,6 +6,7 @@ package Test::Deep::Cmp;
 use overload
   '&' => \&make_all,
   '|' => \&make_any,
+  '~' => \&make_not,
   '""' => \&string,
   fallback => 1,
 ;
@@ -51,6 +52,13 @@ sub make_any
   my ($e1, $e2) = @_;
 
   return Test::Deep::any($e1, $e2);
+}
+
+sub make_not
+{
+  my ($e) = @_;
+
+  return Test::Deep::none($e);
 }
 
 sub cmp

--- a/t/not.t
+++ b/t/not.t
@@ -1,0 +1,69 @@
+use strict;
+use warnings;
+
+use t::std;
+
+{
+  check_test(
+    sub {
+      cmp_deeply("wine", ~any("beer", "wine"))
+    },
+    {
+      actual_ok => 0,
+      diag => <<EOM,
+Comparing \$data with None
+got      : 'wine'
+expected : None of ( Any of ( 'beer', 'wine' ) )
+EOM
+    },
+    "~ eq fail"
+  );
+
+  check_test(
+    sub {
+      cmp_deeply("whisky", ~any("beer", "wine"))
+    },
+    {
+      actual_ok => 1,
+      diag => "",
+    },
+    "~ eq ok"
+  );
+
+  check_test(
+    sub {
+      cmp_deeply("whisky", ~str("beer") | "wine")
+    },
+    {
+      actual_ok => 1,
+      diag => "",
+    },
+    "~ with | match none"
+  );
+
+  check_test(
+    sub {
+      cmp_deeply("wine", ~str("beer") | "wine")
+    },
+    {
+      actual_ok => 1,
+      diag => "",
+    },
+    "~ with | match alternative"
+  );
+
+  check_test(
+    sub {
+      cmp_deeply("beer", ~str("beer") | "wine")
+    },
+    {
+      actual_ok => 0,
+      diag => <<EOM,
+Comparing \$data with Any
+got      : 'beer'
+expected : Any of ( None of ( 'beer' ), 'wine' )
+EOM
+    },
+    "~ with | fail"
+  );
+}


### PR DESCRIPTION
Added overloaded `~` operator for comparison functions. `~$cmp` is short for `none($cmp)`. So you can write

```
re('^foo') & ~str('foobar')
```
