### PR TITLE
make it possible to pick what wraps leafs in want structure

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,10 +1,11 @@
 Revision history for Test-Deep
 
 1.122     2016-09-07
-        - added $Test::Deep::EqObj to control the behavior when the value beign
-          tested is an object and the expected value is a string; when $EqObj
-          is true, they will be compared with `eq`; the default behavior is
-          that any such comparison fails unconditionally
+        - added $Test::Deep::LeafWrapper to control the behavior of simple
+          values in the "expected" definition; by default, they are treated as
+          shallow($x) tests, but you can now say (for example)
+          C<< $Test::Deep::LeafWrapper = \&str >> to always treat the got value
+          as a string, even if blessed, etc.
 
 1.121_001 2016-07-19
         - documentation improvements

--- a/Changes
+++ b/Changes
@@ -1,5 +1,11 @@
 Revision history for Test-Deep
 
+1.122     2016-09-07
+        - added $Test::Deep::EqObj to control the behavior when the value beign
+          tested is an object and the expected value is a string; when $EqObj
+          is true, they will be compared with `eq`; the default behavior is
+          that any such comparison fails unconditionally
+
 1.121_001 2016-07-19
         - documentation improvements
         - avoid a few evals, localize $@ in a few places where eval is used

--- a/lib/Test/Deep.pm
+++ b/lib/Test/Deep.pm
@@ -29,8 +29,8 @@ our @ISA = qw( Exporter );
 
 our $Snobby = 1; # should we compare classes?
 our $Expects = 0; # are we comparing got vs expect or expect vs expect
-our $EqObjs = 0;  # should we compare str/num leafs to objs with eq? (to
-                  # respect possible object overloading, for example)
+
+our $LeafWrapper; # to wrap simple values in a test; if not set, shallow()
 
 our $DNE = \"";
 our $DNE_ADDR = Scalar::Util::refaddr($DNE);
@@ -421,7 +421,9 @@ sub wrap
 
   if($base eq '')
   {
-    $cmp = shallow($data);
+    $cmp = $Test::Deep::LeafWrapper
+         ? $Test::Deep::LeafWrapper->($data)
+         : shallow($data);
   }
   else
   {

--- a/lib/Test/Deep.pm
+++ b/lib/Test/Deep.pm
@@ -29,6 +29,8 @@ our @ISA = qw( Exporter );
 
 our $Snobby = 1; # should we compare classes?
 our $Expects = 0; # are we comparing got vs expect or expect vs expect
+our $EqObjs = 0;  # should we compare str/num leafs to objs with eq? (to
+                  # respect possible object overloading, for example)
 
 our $DNE = \"";
 our $DNE_ADDR = Scalar::Util::refaddr($DNE);

--- a/lib/Test/Deep/Shallow.pm
+++ b/lib/Test/Deep/Shallow.pm
@@ -36,9 +36,19 @@ sub descend
   {
     $ok = refaddr($got) == refaddr($exp);
   }
-  elsif (ref $got xor ref $exp)
+  elsif (! ref $got && ref $exp)
   {
     $ok = 0;
+  }
+  elsif (ref $got && ! ref $exp)
+  {
+    if ($Test::Deep::EqObjs && Scalar::Util::blessed($got))
+    {
+      $ok = $got eq $exp;
+    }
+    else {
+      $ok = 0;
+    }
   }
   else
   {

--- a/lib/Test/Deep/Shallow.pm
+++ b/lib/Test/Deep/Shallow.pm
@@ -36,19 +36,9 @@ sub descend
   {
     $ok = refaddr($got) == refaddr($exp);
   }
-  elsif (! ref $got && ref $exp)
+  elsif (ref $got xor ref $exp)
   {
     $ok = 0;
-  }
-  elsif (ref $got && ! ref $exp)
-  {
-    if ($Test::Deep::EqObjs && Scalar::Util::blessed($got))
-    {
-      $ok = $got eq $exp;
-    }
-    else {
-      $ok = 0;
-    }
   }
   else
   {

--- a/t/shallow.t
+++ b/t/shallow.t
@@ -90,3 +90,38 @@ EOM
     "deep after shallow not eq"
   );
 }
+
+{
+  check_test(
+    sub {
+      cmp_deeply( Test::Deep::EqOverloaded->new, 5);
+    },
+    {
+      actual_ok => 0,
+    },
+    "comparing a plain scalar leaf against obj without eq"
+  );
+
+  local $Test::Deep::EqObjs = 1;
+  check_tests(
+    sub {
+      cmp_deeply( Test::Deep::EqOverloaded->new, 5);
+      cmp_deeply( Test::Deep::EqOverloaded->new, 6);
+    },
+    [
+      {
+        actual_ok => 1,
+      },
+      {
+        actual_ok => 0,
+      },
+    ],
+    "comparing a plain scalar leaf against obj with eq"
+  );
+}
+
+{
+  package Test::Deep::EqOverloaded;
+  use overload q{""} => sub { "5" }, fallback => 1;
+  sub new { my $self = {}; bless $self; }
+}

--- a/t/shallow.t
+++ b/t/shallow.t
@@ -102,7 +102,7 @@ EOM
     "comparing a plain scalar leaf against obj without eq"
   );
 
-  local $Test::Deep::EqObjs = 1;
+  local $Test::Deep::LeafWrapper = \&str;
   check_tests(
     sub {
       cmp_deeply( Test::Deep::EqOverloaded->new, 5);


### PR DESCRIPTION
if I wrote:

```perl
cmp_deeply($want, { foo => { bar => "gurch" } });
```

...then it only passes if `$want->{foo}{bar}` is an unblessed string.  I want a means to say that my default behavior at leaves is to rely on `eq` and trust string overloading.  This change makes it possible to do that by overriding the implicit wrapper put on leafs.