### PR TITLE
when $obj =~ re(...) fails, show "$obj"

### DIFF
--- a/lib/Test/Deep/Regexp.pm
+++ b/lib/Test/Deep/Regexp.pm
@@ -19,7 +19,7 @@ sub init
   if (my $matches = shift)
   {
     $self->{matches} = Test::Deep::regexpmatches($matches, $val);
-    
+
     $self->{flags} = shift || "";
   }
 }
@@ -80,6 +80,23 @@ sub renderExp
   my $self = shift;
 
   return "$self->{val}";
+}
+
+sub renderGot
+{
+  my $self = shift;
+  my $got  = shift;
+
+  if (defined (my $class = Scalar::Util::blessed($got)))
+  {
+    my $ostr = qq{$got};
+    if ($ostr ne overload::StrVal($got))
+    {
+      return qq{'$ostr' (instance of $class)};
+    }
+  }
+
+  return Test::Deep::render_val($got);
 }
 
 1;

--- a/t/regexp.t
+++ b/t/regexp.t
@@ -155,3 +155,32 @@ EOM
   );
 
 }
+
+{
+  require "t/over.pm";
+  my $o = Over->new("hi mom");
+
+  is("$o", "hi mom", "we make a stringifiable object");
+
+  check_test(
+    sub { cmp_deeply($o, re(qr/mom/)); },
+    { actual_ok => 1 },
+    "re() tests objects via overloading",
+  );
+
+  # Remember, Regexp stringification changes over time. -- rjbs, 2016-09-08
+  my $re     = qr/dad/;
+  my $re_str = "$re";
+  check_test(
+    sub { cmp_deeply($o, re($re)); },
+    {
+      actual_ok => 0,
+      diag => <<EOM,
+Using Regexp on \$data
+   got : 'hi mom' (instance of Over)
+expect : $re_str
+EOM
+    },
+    "re() tests objects via overloading",
+  );
+}


### PR DESCRIPTION
We test re(...) against an object with =~ directly, meaning that
=~ or "" overload can matter.  Show the stringified object, if it
differs from the StrVal version.