### PR TITLE
simplify the internal reftype checker

### DIFF
--- a/lib/Test/Deep.pm
+++ b/lib/Test/Deep.pm
@@ -415,11 +415,11 @@ sub wrap
 
   return $data if Scalar::Util::blessed($data) and $data->isa("Test::Deep::Cmp");
 
-  my ($class, $base) = class_base($data);
+  my ($class, $reftype) = class_base($data);
 
   my $cmp;
 
-  if($base eq '')
+  if($reftype eq '')
   {
     $cmp = $Test::Deep::LeafWrapper
          ? $Test::Deep::LeafWrapper->($data)
@@ -431,19 +431,19 @@ sub wrap
 
     return $WrapCache{$addr} if $WrapCache{$addr};
 
-    if($base eq 'ARRAY')
+    if($reftype eq 'ARRAY')
     {
       $cmp = array($data);
     }
-    elsif($base eq 'HASH')
+    elsif($reftype eq 'HASH')
     {
       $cmp = hash($data);
     }
-    elsif($base eq 'SCALAR' or $base eq 'REF')
+    elsif($reftype eq 'SCALAR' or $reftype eq 'REF')
     {
       $cmp = scalref($data);
     }
-    elsif(($base eq 'Regexp') or ($base eq 'REGEXP'))
+    elsif(($reftype eq 'Regexp') or ($reftype eq 'REGEXP'))
     {
       $cmp = regexpref($data);
     }

--- a/lib/Test/Deep.pm
+++ b/lib/Test/Deep.pm
@@ -463,24 +463,20 @@ sub _td_reftype
 {
   my $val = shift;
 
-  if (ref $val)
-  {
-    my $reftype = Scalar::Util::reftype($val);
-    my $blessed = Scalar::Util::blessed($val);
-    return $reftype unless defined $blessed;
+  my $reftype = Scalar::Util::reftype($val);
+  return '' unless defined $reftype;
 
-    if ($Test::Deep::RegexpVersion::OldStyle) {
-      if ($blessed eq "Regexp" and $reftype eq "SCALAR")
-      {
-        $reftype = "Regexp"
-      }
-    }
-    return $reftype;
-  }
-  else
+  return $reftype unless $Test::Deep::RegexpVersion::OldStyle;
+
+  my $blessed = Scalar::Util::blessed($val);
+  return $reftype unless defined $blessed;
+
+  if ($blessed && $blessed eq "Regexp" and $reftype eq "SCALAR")
   {
-    return "";
+    $reftype = "Regexp"
   }
+
+  return $reftype;
 }
 
 sub render_stack

--- a/lib/Test/Deep.pm
+++ b/lib/Test/Deep.pm
@@ -449,7 +449,9 @@ sub wrap
     }
     else
     {
-      $cmp = shallow($data);
+      $cmp = $Test::Deep::LeafWrapper
+           ? $Test::Deep::LeafWrapper->($data)
+           : shallow($data);
     }
 
     $WrapCache{$addr} = $cmp;

--- a/lib/Test/Deep.pm
+++ b/lib/Test/Deep.pm
@@ -91,7 +91,7 @@ while (my ($pkg, $name) = splice @constructors, 0, 2)
 }
 
 {
-  our @EXPORT_OK = qw( descend render_stack class_base cmp_details deep_diag );
+  our @EXPORT_OK = qw( descend render_stack cmp_details deep_diag );
 
   our %EXPORT_TAGS;
   $EXPORT_TAGS{preload} = [];
@@ -415,7 +415,7 @@ sub wrap
 
   return $data if Scalar::Util::blessed($data) and $data->isa("Test::Deep::Cmp");
 
-  my ($class, $reftype) = class_base($data);
+  my $reftype = _td_reftype($data);
 
   my $cmp;
 
@@ -459,16 +459,15 @@ sub wrap
   return $cmp;
 }
 
-sub class_base
+sub _td_reftype
 {
   my $val = shift;
 
   if (ref $val)
   {
-    my $blessed = Scalar::Util::blessed($val);
-    $blessed = defined($blessed) ? $blessed : "";
     my $reftype = Scalar::Util::reftype($val);
-
+    my $blessed = Scalar::Util::blessed($val);
+    return $reftype unless defined $blessed;
 
     if ($Test::Deep::RegexpVersion::OldStyle) {
       if ($blessed eq "Regexp" and $reftype eq "SCALAR")
@@ -476,11 +475,11 @@ sub class_base
         $reftype = "Regexp"
       }
     }
-    return ($blessed, $reftype);
+    return $reftype;
   }
   else
   {
-    return ("", "");
+    return "";
   }
 }
 

--- a/t/deep_utils.t
+++ b/t/deep_utils.t
@@ -4,29 +4,26 @@ use warnings;
 use Test::More 0.88;
 use if $ENV{AUTHOR_TESTING}, 'Test::Warnings';
 
-use Test::Deep qw( cmp_deeply descend render_stack methods deep_diag class_base );
+use Test::Deep qw( cmp_deeply descend render_stack methods deep_diag );
 
 {
   my $a = [];
 
-  my ($class, $base) = class_base($a);
-  is($class, "", "class_base class ref");
-  is($base, "ARRAY", "class_base base ref");
+  my $base = Test::Deep::_td_reftype($a);
+  is($base, "ARRAY", "_td_reftype base ref");
 }
 
 {
   my $a = bless [], "A::Class";
 
-  my ($class, $base) = class_base($a);
-  is($class, "A::Class", "class_base class obj");
-  is($base, "ARRAY", "class_base base obj");
+  my $base = Test::Deep::_td_reftype($a);
+  is($base, "ARRAY", "_td_reftype base obj");
 }
 
 {
   my $a = qr/a/;
 
-  my ($class, $base) = class_base($a);
-  is($class, "Regexp", "class_base class regexp");
+  my $base = Test::Deep::_td_reftype($a);
   is($base, ($] < 5.011 ? "Regexp" : "REGEXP"), "class_base base regexp");
 }
 


### PR DESCRIPTION
This replaces an exportable but seemingly never-used routine with a simpler one.