### PR TITLE
defer wrapping leaves passed to all/any/none

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 Revision history for Test-Deep
 
+1.126_001 2017-04-17
+        - do not eagerly convert simple scalars into tests in the all, any, and
+          none tests; this was breaking LeafWrapper application
+
 1.126     2016-12-27
         - no changes since v1.125_001
 

--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for Test-Deep
 
+1.127     2017-05-04
+        - no code changes from previous release
+
 1.126_001 2017-04-17
         - do not eagerly convert simple scalars into tests in the all, any, and
           none tests; this was breaking LeafWrapper application

--- a/MANIFEST
+++ b/MANIFEST
@@ -67,6 +67,7 @@ t/hashkeys.t
 t/ignore.t
 t/import.t
 t/isa.t
+t/leaf-wrapper.t
 t/lib/Over.pm
 t/lib/Std.pm
 t/listmethods.t

--- a/lib/Test/Deep.pm
+++ b/lib/Test/Deep.pm
@@ -21,7 +21,7 @@ unless (defined $Test::Deep::NoTest::NoTest)
 
 our ($Stack, %Compared, $CompareCache, %WrapCache, $Shallow);
 
-our $VERSION = '1.126_001';
+our $VERSION = '1.127';
 $VERSION =~ tr/_//d;
 
 require Exporter;

--- a/lib/Test/Deep.pm
+++ b/lib/Test/Deep.pm
@@ -21,7 +21,7 @@ unless (defined $Test::Deep::NoTest::NoTest)
 
 our ($Stack, %Compared, $CompareCache, %WrapCache, $Shallow);
 
-our $VERSION = '1.126';
+our $VERSION = '1.126_001';
 $VERSION =~ tr/_//d;
 
 require Exporter;

--- a/lib/Test/Deep/All.pm
+++ b/lib/Test/Deep/All.pm
@@ -13,7 +13,7 @@ sub init
   my @list = map {
     (Scalar::Util::blessed($_) && $_->isa('Test::Deep::All'))
     ? @{ $_->{val} }
-    : Test::Deep::wrap($_)
+    : $_
   } @_;
 
   $self->{val} = \@list;

--- a/lib/Test/Deep/Any.pm
+++ b/lib/Test/Deep/Any.pm
@@ -13,7 +13,7 @@ sub init
   my @list = map {
     (Scalar::Util::blessed($_) && $_->isa('Test::Deep::Any'))
     ? @{ $_->{val} }
-    : Test::Deep::wrap($_)
+    : $_
   } @_;
 
   $self->{val} = \@list;
@@ -36,8 +36,8 @@ sub renderExp
 {
   my $self = shift;
 
-  my $expect = $self->{val};
-  my $things = join(", ", map {$_->renderExp} @$expect);
+  my @expect = map {; Test::Deep::wrap($_) } @{ $self->{val} };
+  my $things = join(", ", map {$_->renderExp} @expect);
 
   return "Any of ( $things )";
 }

--- a/lib/Test/Deep/None.pm
+++ b/lib/Test/Deep/None.pm
@@ -12,7 +12,7 @@ sub init
   my @list = map {
     eval { $_->isa('Test::Deep::None') }
     ? @{ $_->{val} }
-    : Test::Deep::wrap($_)
+    : $_
   } @_;
 
   $self->{val} = \@list;
@@ -35,8 +35,8 @@ sub renderExp
 {
   my $self = shift;
 
-  my $expect = $self->{val};
-  my $things = join(", ", map {$_->renderExp} @$expect);
+  my @expect = map {; Test::Deep::wrap($_) } @{ $self->{val} };
+  my $things = join(", ", map {$_->renderExp} @expect);
 
   return "None of ( $things )";
 }

--- a/t/leaf-wrapper.t
+++ b/t/leaf-wrapper.t
@@ -1,0 +1,68 @@
+use strict;
+use warnings;
+use lib 't/lib';
+
+use Std;
+
+{
+  check_test(
+    sub {
+      cmp_deeply( Test::Deep::EqOverloaded->new, 5);
+    },
+    {
+      actual_ok => 0,
+    },
+    "comparing a plain scalar leaf against obj without eq"
+  );
+
+  {
+    local $Test::Deep::LeafWrapper = \&str;
+    check_tests(
+      sub {
+        cmp_deeply( Test::Deep::EqOverloaded->new, 5);
+        cmp_deeply( Test::Deep::EqOverloaded->new, 6);
+      },
+      [
+        {
+          actual_ok => 1,
+        },
+        {
+          actual_ok => 0,
+        },
+      ],
+      "comparing a plain scalar leaf against obj with eq"
+    );
+  }
+
+  {
+    check_tests(
+      sub {
+        my $t1 = 5;
+        my $t2 = any(5);
+        my $t3 = all(5);
+        local $Test::Deep::LeafWrapper = \&str;
+        cmp_deeply(Test::Deep::EqOverloaded->new, $t1);
+        cmp_deeply(Test::Deep::EqOverloaded->new, $t2);
+        cmp_deeply(Test::Deep::EqOverloaded->new, $t3);
+      },
+      [
+        {
+          actual_ok => 1,
+        },
+        {
+          actual_ok => 1,
+        },
+        {
+          actual_ok => 1,
+        },
+      ],
+      "comparing a plain scalar leaf against obj with eq via any() and all()"
+    );
+  }
+}
+
+{
+  package Test::Deep::EqOverloaded;
+  use overload q{""} => sub { "5" }, fallback => 1;
+  sub new { my $self = {}; bless $self; }
+}

--- a/t/shallow.t
+++ b/t/shallow.t
@@ -91,38 +91,3 @@ EOM
     "deep after shallow not eq"
   );
 }
-
-{
-  check_test(
-    sub {
-      cmp_deeply( Test::Deep::EqOverloaded->new, 5);
-    },
-    {
-      actual_ok => 0,
-    },
-    "comparing a plain scalar leaf against obj without eq"
-  );
-
-  local $Test::Deep::LeafWrapper = \&str;
-  check_tests(
-    sub {
-      cmp_deeply( Test::Deep::EqOverloaded->new, 5);
-      cmp_deeply( Test::Deep::EqOverloaded->new, 6);
-    },
-    [
-      {
-        actual_ok => 1,
-      },
-      {
-        actual_ok => 0,
-      },
-    ],
-    "comparing a plain scalar leaf against obj with eq"
-  );
-}
-
-{
-  package Test::Deep::EqOverloaded;
-  use overload q{""} => sub { "5" }, fallback => 1;
-  sub new { my $self = {}; bless $self; }
-}


### PR DESCRIPTION
Before this change, leaves (plain strings and numbers) passed to
all/any/none were converted to "real tests" with Test::Deep::wrap
during the all/any/none test's initialization.  This meant that
they were subject to the $LeafWrapper in place when any() was called,
rather than when the enclosing cmp_deeply was called.  This meant that
leaves inside and outside of all/any/none were treated differently.

Here's a test, not suitable for inclusion, that demonstrated the
problem:

```perl
  use strict;
  use warnings;

  use JSON;
  use JSON::Typist;
  use Test::Deep;
  use Test::Deep::JType;
  use Test::More;

  my $json = q<{"foo":1}>;
  my $data = JSON::Typist->new->apply_types(decode_json($json));

  jcmp_deeply($data->{foo}, 1);
  jcmp_deeply($data->{foo}, jnum(1));
  jcmp_deeply($data->{foo}, any(jnum(1)));
  jcmp_deeply($data->{foo}, any(1)); # <-- fails, 1 doesn't right wrapper

  done_testing;
```