### PR TITLE
Typo in POD for 'ignore'

### DIFF
--- a/lib/Test/Deep.pm
+++ b/lib/Test/Deep.pm
@@ -972,7 +972,7 @@ or if it is unpredictable.
     $got,
     {
       name    => 'John',
-      rando m => ignore(),
+      random  => ignore(),
       address => [ '5 A street', 'a town', 'a country' ],
     }
   );


### PR DESCRIPTION
`rando m => ignore(),` has a misplaced whitespace.