### PR TITLE
Allow cmp_deeply to be used with NoTest

### DIFF
--- a/lib/Test/Deep.pm
+++ b/lib/Test/Deep.pm
@@ -201,10 +201,18 @@ sub cmp_deeply
 
   my ($ok, $stack) = cmp_details($d1, $d2);
 
-  if (not $Test->ok($ok, $name))
-  {
-    my $diag = deep_diag($stack);
-    $Test->diag($diag);
+  if($Test) {
+    if (not $Test->ok($ok, $name))
+    {
+      my $diag = deep_diag($stack);
+      $Test->diag($diag);
+    }
+  } else {
+    if (not $ok)
+    {
+      my $diag = deep_diag($stack);
+      print $diag;
+    }
   }
 
   return $ok;

--- a/t/notest.t
+++ b/t/notest.t
@@ -6,6 +6,10 @@ use Test::Deep::NoTest;
 # make sure we didn't load Test::Builder
 
 my $ok = not exists( ${Test::Builder::}{"new"});
-print "1..1\n";
+print "1..2\n";
 print $ok ? "" : "not ";
 print "ok 1\n";
+
+my $different = not cmp_deeply([1,2,3], [4,5,6]);
+print $different ? '':  'not ';
+print "ok 2\n";


### PR DESCRIPTION
Allow cmp_deeply to be used with NoTest to deal with bug #60 