### PR TITLE
allow 'use Test::Deep' while other app modules use Test::Deep::NoTest

### DIFF
--- a/lib/Test/Deep.pm
+++ b/lib/Test/Deep.pm
@@ -130,6 +130,15 @@ while (my ($pkg, $name) = splice @constructors, 0, 2)
 
 sub import {
   my $self = shift;
+
+  my $from_notest = grep {$_ eq '_notest'} @_;
+  if ($from_notest) {
+      @_ = grep {$_ ne '_notest'} @_;
+  } else {
+    require Test::Builder;
+    $Test = Test::Builder->new;
+  }
+
   my @sans_preload = grep {; $_ ne ':preload' } @_;
   if (@_ != @sans_preload) {
     require Test::Deep::All;

--- a/lib/Test/Deep/NoTest.pm
+++ b/lib/Test/Deep/NoTest.pm
@@ -18,6 +18,7 @@ sub import {
   # make the stack look like it should for use Test::Deep
   my $pkg = shift;
   unshift(@_, "Test::Deep");
+  push @_, '_notest';
   goto &$import;
 }
 

--- a/t/notest_withtest.t
+++ b/t/notest_withtest.t
@@ -1,0 +1,21 @@
+use strict;
+use warnings;
+
+package Foo {
+    use Test::Deep::NoTest;
+
+    sub check_this {
+        return eq_deeply($_[1], []);
+    }
+}
+
+use Test::More 0.88;
+use if $ENV{AUTHOR_TESTING}, 'Test::Warnings';
+
+use Test::Deep;
+
+ok(Foo->check_this([]), 'notest 1');
+ok(! Foo->check_this({}), 'notest 2');
+cmp_deeply([], [], 'got cmp_deeply');
+
+done_testing;


### PR DESCRIPTION
I think this fixes #53 and #59 (though please double-check), without breaking any tests, plus: adds a new test file, which would have failed without this fix