### PR TITLE
Avoid clobbering $!, $@, and $^E when dynamically loading modules.

### DIFF
--- a/lib/Test/Deep.pm
+++ b/lib/Test/Deep.pm
@@ -79,7 +79,20 @@ while (my ($pkg, $name) = splice @constructors, 0, 2)
   my $file = "$full_pkg.pm";
   $file =~ s#::#/#g;
   my $sub = sub {
+
+    # We might be in the middle of testing one of the globals
+    # that require() overwrites. To simplify test authorship,
+    # we put those overwritten values back below.
+    my $dollar_at = $@;
+    my $dollar_bang = $!;
+    my $dollar_e = $^E;
+
     require $file;
+
+    $@ = $dollar_at;
+    $! = $dollar_bang;
+    $^E = $dollar_e;
+
     return $full_pkg->new(@_);
   };
   {

--- a/t/all_any_noclobber_dollar_at.t
+++ b/t/all_any_noclobber_dollar_at.t
@@ -1,0 +1,17 @@
+use strict;
+use warnings;
+use lib 't/lib';
+
+use Std;
+
+{
+    $@ = 'hello';
+    all(123);
+    is( $@, 'hello', 'all() doesn’t overwrite $@' );
+}
+
+{
+    $@ = 'hello';
+    any(123);
+    is( $@, 'hello', 'any() doesn’t overwrite $@' );
+}

--- a/t/all_any_noclobber_dollar_bang.t
+++ b/t/all_any_noclobber_dollar_bang.t
@@ -1,0 +1,17 @@
+use strict;
+use warnings;
+use lib 't/lib';
+
+use Std;
+
+{
+    $! = 11;
+    all(123);
+    is( 0 + $!, 11, 'all() doesn’t overwrite $!' );
+}
+
+{
+    $! = 11;
+    any(123);
+    is( 0 + $!, 11, 'any() doesn’t overwrite $!' );
+}

--- a/t/all_any_noclobber_dollar_e.t
+++ b/t/all_any_noclobber_dollar_e.t
@@ -1,0 +1,17 @@
+use strict;
+use warnings;
+use lib 't/lib';
+
+use Std;
+
+{
+    $^E = 11;
+    all(123);
+    is( 0 + $^E, 11, 'all() doesn’t overwrite $^E' );
+}
+
+{
+    $^E = 11;
+    any(123);
+    is( 0 + $^E, 11, 'any() doesn’t overwrite $^E' );
+}


### PR DESCRIPTION
Issue #36

This prevents clobbering globals that may be under test when all()/any() are called.