### PR TITLE
Set: do not deduplicate Cmp objects

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for Test-Deep
 
 {{$NEXT}}
+        - when loading the various test modules, preserve global variables like
+          $@; thanks, Felipe Gasper
 
 1.202     2023-01-04 20:40:46-05:00 America/New_York
         - no changes since trial releases


### PR DESCRIPTION
You can't really tell whether they are equivalent!

Sadly, this breaks some tests.

See #82 