### PR TITLE
add missing documentation for reftype

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for Test-Deep
 
 {{$NEXT}}
+        - add documentation for reftype() (Karen Etheridge)
 
 1.205     2025-04-01 11:01:50-04:00 America/New_York
         - add "use v5.12" to Test::Deep, just for clarity

--- a/lib/Test/Deep.pm
+++ b/lib/Test/Deep.pm
@@ -1281,6 +1281,13 @@ to patch over the fact that C<isa> is exported by default.
 This test accepts only objects that are instances of C<$class> or a subclass.
 Unlike the C<Isa> test, this test will never accept class names.
 
+=head3 reftype
+
+  cmp_deeply( $got, reftype('CODE') );
+
+This test only accepts values that are of the reftype passed to the subroutine,
+for example C<HASH>, C<ARRAY>, C<SCALAR>, C<GLOB> or C<CODE>.
+
 =head3 array_each
 
   cmp_deeply( \@got, array_each($thing) );


### PR DESCRIPTION
Imagine my surprise when I went looking to see if there was a `reftype()`, found nothing in the docs, but when I defined my own local version it collided with an import from Test::Deep! :o